### PR TITLE
.ui-tabs-active was not referenced

### DIFF
--- a/css/custom-theme/jquery-ui-1.8.16.custom.css
+++ b/css/custom-theme/jquery-ui-1.8.16.custom.css
@@ -853,9 +853,13 @@ button.ui-button::-moz-focus-inner { border: 0; padding: 0; } /* reset extra pad
 
 
  }
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected { margin-bottom: 0; padding-bottom: 0px; outline:none;}
+.ui-tabs .ui-tabs-nav li.ui-tabs-selected,
+.ui-tabs .ui-tabs-nav li.ui-tabs-active { margin-bottom: 0; padding-bottom: 0px; outline:none;}
 
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected a, .ui-tabs .ui-tabs-nav li.ui-state-disabled a, .ui-tabs .ui-tabs-nav li.ui-state-processing a {
+.ui-tabs .ui-tabs-nav li.ui-tabs-selected a,
+.ui-tabs .ui-tabs-nav li.ui-state-disabled a,
+.ui-tabs .ui-tabs-nav li.ui-state-processing a,
+.ui-tabs .ui-tabs-nav li.ui-tabs-active a {
 
   background-color: #ffffff;
   border: 1px solid #ddd;
@@ -866,7 +870,7 @@ button.ui-button::-moz-focus-inner { border: 0; padding: 0; } /* reset extra pad
 }
 
 
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected:hover{
+.ui-tabs .ui-tabs-nav li.ui-tabs-selected:hover, .ui-tabs .ui-tabs-nav li.ui-tabs-active:hover {
   background:#ffffff;
   outline:none;
 }


### PR DESCRIPTION
When using UI Tabs in an ajax loading context, jQuery UI seems to use the class .ui-tabs-active for the active state. I've included these classes so that the styles of an active tab get applied correctly.
