### PR TITLE
Updated ui.daterangepicker.css

### DIFF
--- a/third-party/jQuery-UI-Date-Range-Picker/css/ui.daterangepicker.css
+++ b/third-party/jQuery-UI-Date-Range-Picker/css/ui.daterangepicker.css
@@ -79,6 +79,7 @@
 }
 
 .ui-daterangepicker .ui-state-hover{
+	padding: 1px;
 	background:#0064CD;
 	color:#fff;
 }


### PR DESCRIPTION
Updated ui.daterangepicker.css to include padding on the hover state of the menu. Without this the padding was 0 which meant the text would jump and you wouldn't see a blue hover. Tested in Chrome.
