### PR TITLE
Fix of fix for wijmo menu

### DIFF
--- a/css/custom-theme/jquery-ui-1.8.16.custom.css
+++ b/css/custom-theme/jquery-ui-1.8.16.custom.css
@@ -1279,8 +1279,8 @@ div.wijmo-wijmenu .wijmo-wijmenu-child .wijmo-wijmenu-text
 /* Fix for wijmo separator not being centered. */
 /* Hate having to add the li.wijmo-wijmenu-separator at the end, but because of order of CSS files being loaded, I needed to up the specificity level. */
 .wijmo-wijmenu-horizontal .wijmo-wijmenu-child li.wijmo-wijmenu-separator{
-  width:98%;
-  margin:1px 1%;
+  width:96%;
+  margin:1px 2%;
 }
 
 .wijmo-wijmenu .wijmo-wijmenu-item input {


### PR DESCRIPTION
Margin of 1% didn't work well enough in all browsers, probably to do with sub-pixel positioning.
A margin 2% works well.
