### PR TITLE
Removed WebKit focus halo for dialog buttons in buttonset and fixed Dialog close button from flickering.

### DIFF
--- a/css/custom-theme/jquery-ui-1.8.16.custom.css
+++ b/css/custom-theme/jquery-ui-1.8.16.custom.css
@@ -724,10 +724,12 @@ button.ui-button::-moz-focus-inner { border: 0; padding: 0; } /* reset extra pad
   text-indent: 9999px;
 }
 
-.ui-dialog .ui-dialog-titlebar-close:hover, .ui-dialog .ui-dialog-titlebar-close:focus { padding: 0;   filter: alpha(opacity=90);
+.ui-dialog .ui-dialog-titlebar-close:hover, .ui-dialog .ui-dialog-titlebar-close:focus {
+  filter: alpha(opacity=90);
   -khtml-opacity: 0.90;
   -moz-opacity: 0.90;
-  opacity: 0.90;   }
+  opacity: 0.90;
+}
 
 .ui-dialog .ui-dialog-content { position: relative; border: 0; padding: .5em 1em; background: none; overflow: auto; zoom: 1; }
 

--- a/css/custom-theme/jquery-ui-1.8.16.custom.css
+++ b/css/custom-theme/jquery-ui-1.8.16.custom.css
@@ -549,6 +549,11 @@
 
 } /* the overflow property removes extra width in IE */
 
+/* Remove the focus ring for default button in dialog buttonset. */
+.ui-dialog-buttonset .ui-button:focus {
+  outline:none;
+}
+
 .ui-button-primary {
   color: #ffffff;
   background-color: #0064cd;


### PR DESCRIPTION
Regarding the second change: "Fixed close button in dialogs (.ui-dialog-titlebar-close) flickering when mouse was at the bottom or left margin of it."

Because it had a padding of 1px in its normal state and a padding of 0 in it's hover state, this caused it to move 1px from its position on mouse over, meaning that if mouse was at the bottom or left, the close button would "run away" from the mouse, then come back because moving 1px away meant the mouse was no longer over it and so on for all eternity... or when mouse was moved more than 1px away, whichever came first.
