### PR TITLE
Fixed Accordion headers

### DIFF
--- a/css/custom-theme/jquery-ui-1.8.16.custom.css
+++ b/css/custom-theme/jquery-ui-1.8.16.custom.css
@@ -450,6 +450,20 @@
 .ui-accordion .ui-accordion-header .ui-icon { position: absolute; left: .5em; top: 50%; margin-top: -8px; }
 .ui-accordion .ui-accordion-content { padding: 1em 2.2em; border-top: 0; margin-top: -2px; position: relative; top: 1px; margin-bottom: 2px; overflow: auto; display: none; zoom: 1; }
 .ui-accordion .ui-accordion-content-active { display: block; }
+/* .ui-accordion .ui-state-active[aria-expanded="true"] is for setting styles on the first header which is expanded by default but does not get a class of  */
+.ui-accordion .ui-accordion-header.ui-state-active {
+  background-color: #E6E6E6;
+  background-repeat: no-repeat;
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffffff), color-stop(25%, #ffffff), to(#e6e6e6));
+  background-image: -webkit-linear-gradient(#ffffff, #ffffff 25%, #e6e6e6);
+  background-image: -moz-linear-gradient(top, #ffffff, #ffffff 25%, #e6e6e6);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff', endColorstr='#e6e6e6', GradientType=0);
+  background-image: -ms-linear-gradient(#ffffff, #ffffff 25%, #e6e6e6);
+  background-image: -o-linear-gradient(#ffffff, #ffffff 25%, #e6e6e6);
+  background-image: linear-gradient(#ffffff, #ffffff 25%, #e6e6e6);
+  background-position:0 -15px;/*Without this, it loses highlight provided by .ui-state-focus when focus is lost, simply by clicking elsewhere on the page.*/
+}
+
 /*
  * jQuery UI Autocomplete 1.8.16
  *


### PR DESCRIPTION
Fixed Accordion headers
- losing styling when selected (white background)
- losing style when selected header lost focus
- when Accordion first loaded, the first expanded header did not have apropriate styling (.ui-state-active) but default (.ui-state-default) styling
