### PR TITLE
CSS Change between 1.9.1 and 1.9.2

### DIFF
--- a/css/custom-theme/jquery-ui-1.9.1.custom.css
+++ b/css/custom-theme/jquery-ui-1.9.1.custom.css
@@ -12,7 +12,7 @@
 /* Layout helpers
 ----------------------------------*/
 .ui-helper-hidden { display: none; }
-.ui-helper-hidden-accessible { position: absolute !important; clip: rect(1px 1px 1px 1px); clip: rect(1px,1px,1px,1px); }
+.ui-helper-hidden-accessible { border: 0; clip: rect(0 0 0 0); height: 1px; margin: -1px; overflow: hidden; padding: 0; position: absolute; width: 1px; }
 .ui-helper-reset { margin: 0; padding: 0; border: 0; outline: 0; line-height: 1.3; text-decoration: none; font-size: 100%; list-style: none; }
 .ui-helper-clearfix:after { content: "."; display: block; height: 0; clear: both; visibility: hidden; }
 .ui-helper-clearfix { display: inline-block; }
@@ -461,7 +461,8 @@
  */
 .ui-autocomplete { 
 	position: absolute; 
-	top: 0; /* #8656 */
+	top: 0;
+	left: 0;
 	cursor: default; 
 }
 


### PR DESCRIPTION
Hi just after 1.9.1 there is 1.9.2 ;-)

I was able to apply the changes of :
https://github.com/jquery/jquery-ui/commit/8f0daea9eb0b5e6feb31b1e69878919bce78cef1
https://github.com/jquery/jquery-ui/commit/db1a622900250eef3be2dff23d17a00dbc15a1d3

All this change don't seems like to new javascript... they should be ok with 1.9.1 js ...

All the other changes in the changelog are on the javascript
