### PR TITLE
restored normal color links for modal dialogs

### DIFF
--- a/components.html
+++ b/components.html
@@ -349,8 +349,8 @@ $("#menu-collapse").accordion({
     <div id="dialog-message" title="Modal Dialog">
         <p>
             <span class="ui-icon ui-icon-circle-check" style="float:left; margin:0 7px 50px 0;"></span>
-            Your files have downloaded successfully into the My Downloads folder.
-        </p>
+    Your files have downloaded successfully into the <a href="#">My Downloads</a> folder.
+</p>
         <p>
             Currently using <b>36% of your storage space</b>.
         </p>

--- a/css/custom-theme/jquery-ui-1.10.1.custom.css
+++ b/css/custom-theme/jquery-ui-1.10.1.custom.css
@@ -257,10 +257,6 @@
 	color: #404040;
 }
 
-.ui-widget-content a {
-	color: #404040;
-}
-
 .ui-widget-header {
 	font-weight: bold;
 	border-color: #0064cd #0064cd #003f81;


### PR DESCRIPTION
closes #166

Side: I also noticed that the links in the modal dialog are automatically selected (a grey box in Chrome). Is this intended or not?
