### PR TITLE
Now only first button in dialog is primary

### DIFF
--- a/components.html
+++ b/components.html
@@ -349,8 +349,8 @@ $("#menu-collapse").accordion({
     <div id="dialog-message" title="Modal Dialog">
         <p>
             <span class="ui-icon ui-icon-circle-check" style="float:left; margin:0 7px 50px 0;"></span>
-    Your files have downloaded successfully into the <a href="#">My Downloads</a> folder.
-</p>
+            Your files have downloaded successfully into the <a href="#">My Downloads</a> folder.
+        </p>
         <p>
             Currently using <b>36% of your storage space</b>.
         </p>

--- a/css/custom-theme/jquery-ui-1.10.1.custom.css
+++ b/css/custom-theme/jquery-ui-1.10.1.custom.css
@@ -2293,7 +2293,7 @@ textarea,
 
 /***Dialog fixes**/
 
-.ui-dialog-buttonset .ui-button:nth-child(2) {
+.ui-dialog-buttonset .ui-button:not(:first-child) {
 	cursor: pointer;
 	display: inline-block;
 	background-color: #e6e6e6;


### PR DESCRIPTION
closes #156

![Selection_001](https://f.cloud.github.com/assets/283733/378085/1f27110e-a516-11e2-8872-fad430ef6bf0.png)

The code for the screenshot was

``` javascript
 // Dialog Simple
    $('#dialog_simple').dialog({
        autoOpen: false,
        width: 600,
        buttons: {
            "Ok": function () {
                $(this).dialog("close");
            },
            "Cancel": function () {
                $(this).dialog("close");
            },
            "Test": function () {}
        }
    });
```

Tested in FF stable and chrome-dev
