### PR TITLE
Update jquery-ui-1.10.3.custom.css

### DIFF
--- a/css/custom-theme/jquery-ui-1.10.3.custom.css
+++ b/css/custom-theme/jquery-ui-1.10.3.custom.css
@@ -1535,7 +1535,7 @@ button.ui-button::-moz-focus-inner {
 	background-image: -webkit-linear-gradient(top, #049cdb, #0064cd); /* Safari 5.1+, Chrome 10+ */
 	background-image: -moz-linear-gradient(top, #049cdb, #0064cd); /* Firefox 3.6 */
 	background-image: -o-linear-gradient(top, #049cdb, #0064cd); /* Opera 11.10+ */
-	background-image: linear-gradient(top, #049cdb, #0064cd); /* CSS3 Compliant */
+	background-image: linear-gradient(to bottom, #049cdb, #0064cd); /* CSS3 Compliant */
 	filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#049cdb', endColorstr='#0064cd', GradientType=0); /* IE8 */
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 	border-color: #0064cd #0064cd #003f81;


### PR DESCRIPTION
IE 10 seems to require the direction keyword 'to' in the linear-gradient which looks to be the new syntax being adopted.
http://stackoverflow.com/questions/2621632/is-there-an-official-standard-css3-gradient-syntax
