### PR TITLE
fixes overlapping of multiple jQuery UI modal dialogs

### DIFF
--- a/css/custom-theme/jquery-ui-1.10.3.custom.css
+++ b/css/custom-theme/jquery-ui-1.10.3.custom.css
@@ -226,7 +226,7 @@
  * Dual licensed under the MIT or GPL Version 2 licenses.
  * http://jquery.org/license
  *
- * 
+ *
  *
  * To view and modify this theme, visit http://jqueryui.com/themeroller/
  */
@@ -1023,7 +1023,7 @@
 .ui-button-primary:hover,
 .ui-button-success:hover,
 .ui-button-info:hover,
-.ui-button-danger:hover, 
+.ui-button-danger:hover,
 .ui-button-warning:hover,
 .ui-button-inverse:hover{
 	color: #ffffff;
@@ -1173,7 +1173,7 @@ input.ui-button {
 button.ui-button::-moz-focus-inner {
 	border: 0;
 	padding: 0;
-} 
+}
 
 
 /*
@@ -1211,7 +1211,7 @@ button.ui-button::-moz-focus-inner {
 	  line-height: 0;
 	}
 
-	li.ui-menu-item { 
+	li.ui-menu-item {
 	  /* This fixes the IE10 issue (jQuery UI Issue #8844)*/
 	  list-style-type: none;
 	}
@@ -1414,7 +1414,9 @@ button.ui-button::-moz-focus-inner {
 	outline: medium none;
 	/*top: 10%;
 	width: 560px;*/
-	z-index: 1050;
+
+	/* juristr: fixes multiple modal ui-dialogs, otherwise it doesn't work */
+	/*z-index: 1050;*/
 }
 .ui-dialog .ui-dialog-titlebar {
 	/*padding: .4em 1em;*/
@@ -1479,7 +1481,7 @@ button.ui-button::-moz-focus-inner {
 	padding: 1px;
 	filter:alpha(opacity=90);
 	-moz-opacity: 0.90;
-	opacity: 0.90;	 
+	opacity: 0.90;
 }
 
 .ui-dialog .ui-dialog-content {


### PR DESCRIPTION
I noticed that when I open a modal dialog inside another modal then thy don't properly overlap, meaning you can click on the parent dialog which you shouldn't be able to as the child dialog has been opened in modal-mode as well:

**Before:**

![jquery-ui-dialog-before](https://f.cloud.github.com/assets/542458/1334674/00770ba6-35ad-11e3-82ef-f61297bb6869.png)

**After the fix**

![jquery-ui-dialog-after](https://f.cloud.github.com/assets/542458/1334676/0b2f9234-35ad-11e3-8e66-3b54eb456ab1.png)

I hope I didn't break any other working behavior.

(maybe this fixes issue #191 as it seems to be related to this if I got it correctly...)
