### PR TITLE
Removed '.ui-widget :active' selector because of the performance problem

### DIFF
--- a/less/jq-ui-bootstrap/core.less
+++ b/less/jq-ui-bootstrap/core.less
@@ -91,10 +91,6 @@
 	}
 }
 
-.ui-widget :active {
-	outline: none;
-}
-
 /* Interaction Cues
 ----------------------------------*/
 


### PR DESCRIPTION
I found a very slow selector:

```
.ui-widget :active {
  outline: none;
}
```

I have a complex HTML page containing a large grid (with more than 500 rows). After importing `jq-ui-bootstrap.less` every click lasts about 500ms. Delay is the same even if there isn't any ascendant element with `.ui-widget` class.
After some experiments I found that the reason of these lags is the selector above. When I comment it, all works fine. I don't know why this selector is so slow, but it's bad practice to use the descendant selector in any case. I suppose `outline: none` was introduced mostly for `<a>` tags. But it was already done in Bootstrap, see 'normalize.less':

```
a:active,
a:hover {
  outline: 0;
}
```

So I think the selector `.ui-widget :active` can be safely deleted.
