### PR TITLE
Removed 'position:relative' for .ui-state-*

### DIFF
--- a/less/jq-ui-bootstrap/core.less
+++ b/less/jq-ui-bootstrap/core.less
@@ -97,7 +97,6 @@
 .ui-state-highlight,
 .ui-state-error,
 .ui-state-default {
-	position: relative;
 	border-width: 1px;
 	border-style: solid;
 }


### PR DESCRIPTION
I suppose style `position: relative` is too restrictive for .ui-state-\* selectors. For example here is description for `.ui-state-default` from http://api.jqueryui.com/:

> Class to be applied to clickable button-like elements. Applies "clickable default" container styles to an element and its child text, links, and icons.

Why button-like elements should always have relative position?
Also I didn't find this style in standard jQuery UI themes.
