### PR TITLE
reflect Bootstrap's branding change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #jQuery UI Bootstrap (v 1.0 Alpha)
 
-This project was started to bring the beauty and ease-of-use of Twitter Bootstrap to jQuery UI widgets ♥.
+This project was started to bring the beauty and ease-of-use of Bootstrap to jQuery UI widgets ♥.
 
 
 ##Why?
@@ -10,7 +10,7 @@ Bootstrap is one of our favorite projects, but having used it regularly it left 
 * The ability to work side-by-side with jQuery UI (something which caused a number of widgets to break visually)
 * The ability to theme jQuery UI widgets using Bootstrap styles. Whilst we love jQuery UI, we find some of the current themes to look a little dated. Our hope is that this theme provides a decent alternative for others that feel the same.
 
-To clarify, this project doesn't aim or intend to replace Twitter Bootstrap. It merely provides a jQuery UI-compatible theme inspired by Bootstrap's design. It also provides a version of Bootstrap CSS with a few (minor) sections commented out which enable the theme to work alongside it.
+To clarify, this project doesn't aim or intend to replace Bootstrap. It merely provides a jQuery UI-compatible theme inspired by Bootstrap's design. It also provides a version of Bootstrap CSS with a few (minor) sections commented out which enable the theme to work alongside it.
 
 We welcome any and all feedback as we would very much like this theme to be as solid as possible.
 

--- a/components.html
+++ b/components.html
@@ -1179,7 +1179,7 @@ $( "#tooltip-bottom" ).tooltip({
                 <h3><span class="icon-lightbulb"></span> Credits</h3>
                 <ul class="list-unstyled">
                     <li>jQuery UI Bootstrap &copy; <strong class="text-info">Addy Osmani</strong> 2012 - 2013.</li>
-                    <li>Twitter Bootstrap &copy; <strong class="text-info">Twitter</strong> 2012 - 2013</li>
+                    <li>Bootstrap &copy; <strong class="text-info">Twitter, Inc.</strong> 2012 - 2013</li>
                 </ul>
             </div>
         </div>

--- a/css/custom-theme/jquery-ui-1.10.3.custom.css
+++ b/css/custom-theme/jquery-ui-1.10.3.custom.css
@@ -5,7 +5,7 @@
  * Copyright 2012 - 2013, Addy Osmani
  * Dual licensed under the MIT or GPL Version 2 licenses.
  *
- * Portions copyright jQuery UI & Twitter Bootstrap
+ * Portions copyright jQuery UI & Twitter, Inc.
  */
 
 /********** VJ - Move to Less - Start *************/

--- a/extra.html
+++ b/extra.html
@@ -131,7 +131,7 @@
                     <h1>Wijmo</h1>
                 </div>
                 <p>
-                    This is an example of how to retheme one of the Wijmo jQuery UI components to match the Twitter Bootstrap theme. Whilst a menu component will be arriving to jQueryUI soon, you can find the menu in <a href="http://wijmo.com/widgets/wijmo-open/">Wijmo Open</a>.
+                    This is an example of how to retheme one of the Wijmo jQuery UI components to match the Bootstrap theme. Whilst a menu component will be arriving to jQueryUI soon, you can find the menu in <a href="http://wijmo.com/widgets/wijmo-open/">Wijmo Open</a>.
                 </p>
                 <div id="wijmo-container" class="container">
                     <ul id="menu1">
@@ -408,7 +408,7 @@ $( "#rerun-fa" )
                 <h3><span class="icon-lightbulb"></span> Credits</h3>
                 <ul class="list-unstyled">
                     <li>jQuery UI Bootstrap &copy; <strong class="text-info">Addy Osmani</strong> 2012 - 2013.</li>
-                    <li>Twitter Bootstrap &copy; <strong class="text-info">Twitter</strong> 2012 - 2013</li>
+                    <li>Bootstrap &copy; <strong class="text-info">Twitter, Inc.</strong> 2012 - 2013</li>
                 </ul>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -117,8 +117,8 @@
                 <h1><span class="label label-default">1</span> Download</h1>
             </div>
             <p class="docs-lead">
-                    Welcome! This is a live preview of jQuery UI Bootstrap - a project we started to bring the beauty of Twitter <a class="targetblank" href="http://getbootstrap.com">Bootstrap</a> to jQuery UI widgets.
-                    With this theme, not only do you get the ability to use Bootstrap-themed widgets, but you can now also use (most) of Twitter Bootstrap side-by-wide with it without components breaking visually.
+                    Welcome! This is a live preview of jQuery UI Bootstrap - a project we started to bring the beauty of <a class="targetblank" href="http://getbootstrap.com">Bootstrap</a> to jQuery UI widgets.
+                    With this theme, not only do you get the ability to use Bootstrap-themed widgets, but you can now also use (most) of Bootstrap side-by-wide with it without components breaking visually.
             </p>
             <p>
                 <a class="download-btn ui-button-primary" href="https://github.com/addyosmani/jquery-ui-bootstrap/zipball/v0.5pre">Download stable (v0.5)</a>
@@ -132,10 +132,10 @@
             <div class="page-header">
                 <h1><span class="label label-default">2</span> Start with jQuery UI Bootstrap</h1>
             </div>
-            <h2>Compatibility jQuery UI and Twitter Bootstrap</h2>
+            <h2>Compatibility jQuery UI and Bootstrap</h2>
 
             <p>
-                In their original forms, jQuery UI and Bootstrap can't coexist resulting in conflicts with both CSS classes and styles as well as JavaScript when you do try to use them. jQuery UI Bootstrap provides the JavaScript and CSS required to quickly start a project using both jQuery UI and Twitter Bootstrap.
+                In their original forms, jQuery UI and Bootstrap can't coexist resulting in conflicts with both CSS classes and styles as well as JavaScript when you do try to use them. jQuery UI Bootstrap provides the JavaScript and CSS required to quickly start a project using both jQuery UI and Bootstrap.
             </p>
             <p>
                 Our solution offers a custom version of Bootstrap compatible with jQuery UI as well as a Bootstrap-themed jQuery UI theme you can use to prototype your projects.
@@ -145,7 +145,7 @@
                 <thead>
                 <tr>
                     <th>jQuery UI</th>
-                    <th>Twitter Bootstrap</th>
+                    <th>Bootstrap</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -169,7 +169,7 @@
                 <tr>
                     <th>Widget</th>
                     <th>jQuery UI</th>
-                    <th>Twitter Bootstrap</th>
+                    <th>Bootstrap</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -188,7 +188,7 @@
             <div class="alert alert-info">
                 <span class="icon-lightbulb icon-large"></span>  Select custom jQuery UI components (eg exclude tooltip)
             </div>
-            <h3> Twitter Bootstrap components</h3>
+            <h3>Bootstrap components</h3>
             <div class="row">
                 <ul class="list-unstyled">
                     <li class="col-sm-6 col-lg-3 col-sm-3">
@@ -216,7 +216,7 @@
                 <tr>
                     <th>Widget</th>
                     <th>jQuery UI</th>
-                    <th>Twitter Bootstrap</th>
+                    <th>Bootstrap</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -236,7 +236,7 @@
                 Selecting which jQuery UI and Bootstrap components and styles we wish to use, we can benefit from the advantages of both projects. jQuery UI Bootstrap also provides Bootstrap theming for a number of third-party jQuery UI widgets such as the Wijmo menu widget and others.
             </p>
             <p>
-                Note: if you want to use Font awesome with Twitter Bootstrap, you must exclude the CSS component icons.
+                Note: if you want to use Font Awesome with Bootstrap, you must exclude the CSS component icons.
             </p>
             <p>
                 The Awesome Font documentation indicates this information perfectly.
@@ -283,7 +283,7 @@
                 <h3><span class="icon-lightbulb"></span> Credits</h3>
                 <ul class="list-unstyled">
                     <li>jQuery UI Bootstrap &copy; <strong class="text-info">Addy Osmani</strong> 2012 - 2013.</li>
-                    <li>Twitter Bootstrap &copy; <strong class="text-info">Twitter</strong> 2012 - 2013</li>
+                    <li>Bootstrap &copy; <strong class="text-info">Twitter, Inc.</strong> 2012 - 2013</li>
                 </ul>
             </div>
         </div>

--- a/less/bootstrap/component-animations.less
+++ b/less/bootstrap/component-animations.less
@@ -5,7 +5,7 @@
 // Heads up!
 //
 // We don't use the `.opacity()` mixin here since it causes a bug with text
-// fields in IE7-8. Source: https://github.com/twitter/bootstrap/pull/3552.
+// fields in IE7-8. Source: https://github.com/twbs/bootstrap/pull/3552.
 
 .fade {
   opacity: 0;

--- a/less/jq-ui-bootstrap/accordion.less
+++ b/less/jq-ui-bootstrap/accordion.less
@@ -4,7 +4,7 @@
  * jQuery UI Accordion 1.10.3
  * http://jqueryui.com/accordion/
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/autocomplete.less
+++ b/less/jq-ui-bootstrap/autocomplete.less
@@ -4,7 +4,7 @@
  * jQuery UI Autocomplete 1.10.3
  * http://docs.jquery.com/UI/Autocomplete#theming
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/button.less
+++ b/less/jq-ui-bootstrap/button.less
@@ -4,7 +4,7 @@
  * jQuery UI Button 1.10.3
  * http://docs.jquery.com/UI/Button#theming
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/core.less
+++ b/less/jq-ui-bootstrap/core.less
@@ -3,7 +3,7 @@
  *
  * jQuery UI CSS Framework 1.10.3
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/datepicker.less
+++ b/less/jq-ui-bootstrap/datepicker.less
@@ -4,7 +4,7 @@
  * jQuery UI Datepicker 1.10.3
  * http://docs.jquery.com/UI/Datepicker#theming
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/dialog.less
+++ b/less/jq-ui-bootstrap/dialog.less
@@ -4,7 +4,7 @@
  * jQuery UI Dialog 1.10.3
  * http://docs.jquery.com/UI/Dialog#theming
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/jq-ui-bootstrap-mixin-adapter.less
+++ b/less/jq-ui-bootstrap/jq-ui-bootstrap-mixin-adapter.less
@@ -1,6 +1,6 @@
 /*
  * jQuery UI Bootstrap v1.0 Alpha (Mixins)
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT.
  */

--- a/less/jq-ui-bootstrap/jq-ui-bootstrap.less
+++ b/less/jq-ui-bootstrap/jq-ui-bootstrap.less
@@ -1,6 +1,6 @@
 /*!
  * jQuery UI Bootstrap v1.0 Alpha
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/menu.less
+++ b/less/jq-ui-bootstrap/menu.less
@@ -4,7 +4,7 @@
  * jQuery UI Menu 1.10.3
  * http://docs.jquery.com/UI/Menu#theming
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/progressbar.less
+++ b/less/jq-ui-bootstrap/progressbar.less
@@ -4,7 +4,7 @@
  * jQuery UI Progressbar 1.10.3
  * http://jqueryui.com/tooltip/
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/resizable.less
+++ b/less/jq-ui-bootstrap/resizable.less
@@ -4,7 +4,7 @@
  * jQuery UI Resizable 1.10.3
  * http://api.jqueryui.com/resizable/
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/selectable.less
+++ b/less/jq-ui-bootstrap/selectable.less
@@ -4,7 +4,7 @@
  * jQuery UI Selectable 1.10.3
  * http://jqueryui.com/selectable/
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/slider.less
+++ b/less/jq-ui-bootstrap/slider.less
@@ -2,7 +2,7 @@
  * jQuery UI Slider 1.10.3
  * http://docs.jquery.com/UI/Slider#theming
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/spinner.less
+++ b/less/jq-ui-bootstrap/spinner.less
@@ -4,7 +4,7 @@
  * jQuery UI spinner 1.10.3
  * http://docs.jquery.com/UI/Menu#theming
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/tabs.less
+++ b/less/jq-ui-bootstrap/tabs.less
@@ -4,7 +4,7 @@
  * jQuery UI Tabs 1.10.3
  * http://docs.jquery.com/UI/Tabs#theming
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/less/jq-ui-bootstrap/tooltip.less
+++ b/less/jq-ui-bootstrap/tooltip.less
@@ -4,7 +4,7 @@
  * jQuery UI Tooltip 1.10.3
  * http://jqueryui.com/tooltip/
  *
- * Portions copyright Addy Osmani, jQuery UI & Twitter Bootstrap
+ * Portions copyright Addy Osmani, jQuery UI & Twitter, Inc.
  * Created the LESS version by @dharapvj
  * Released under MIT
  */

--- a/map.html
+++ b/map.html
@@ -307,7 +307,7 @@ $("#tabs").tabs({
                 <h3><span class="icon-lightbulb"></span> Credits</h3>
                 <ul class="list-unstyled">
                     <li>jQuery UI Bootstrap &copy; <strong class="text-info">Addy Osmani</strong> 2012 - 2013.</li>
-                    <li>Twitter Bootstrap &copy; <strong class="text-info">Twitter</strong> 2012 - 2013</li>
+                    <li>Bootstrap &copy; <strong class="text-info">Twitter, Inc.</strong> 2012 - 2013</li>
                 </ul>
             </div>
         </div>

--- a/theme/base/components.html
+++ b/theme/base/components.html
@@ -1183,7 +1183,7 @@ $( "#tooltip-bottom" ).tooltip({
                     <h3><span class="icon-lightbulb"></span> Credits</h3>
                 <ul class="list-unstyled">
                         <li>jQuery UI Bootstrap &copy; <strong class="text-info">Addy Osmani</strong> 2012 - 2013.</li>
-                        <li>Twitter Bootstrap &copy; <strong class="text-info">Twitter</strong> 2012 - 2013</li>
+                        <li>Bootstrap &copy; <strong class="text-info">Twitter, Inc.</strong> 2012 - 2013</li>
                     </ul>
                 </div>
             </div>

--- a/theme/base/extra.html
+++ b/theme/base/extra.html
@@ -133,7 +133,7 @@
                     <h1>Wijmo</h1>
                 </div>
                 <p>
-                    This is an example of how to retheme one of the Wijmo jQuery UI components to match the Twitter Bootstrap theme. Whilst a menu component will be arriving to jQueryUI soon, you can find the menu in <a href="http://wijmo.com/widgets/wijmo-open/">Wijmo Open</a>.
+                    This is an example of how to retheme one of the Wijmo jQuery UI components to match the Bootstrap theme. Whilst a menu component will be arriving to jQueryUI soon, you can find the menu in <a href="http://wijmo.com/widgets/wijmo-open/">Wijmo Open</a>.
                 </p>
                 <div id="wijmo-container" class="container">
                     <ul id="menu1">
@@ -410,7 +410,7 @@ $( "#rerun-fa" )
                 <h3><span class="icon-lightbulb"></span> Credits</h3>
                 <ul class="list-unstyled">
                     <li>jQuery UI Bootstrap &copy; <strong class="text-info">Addy Osmani</strong> 2012 - 2013.</li>
-                    <li>Twitter Bootstrap &copy; <strong class="text-info">Twitter</strong> 2012 - 2013</li>
+                    <li>Bootstrap &copy; <strong class="text-info">Twitter, Inc.</strong> 2012 - 2013</li>
                 </ul>
             </div>
           </div>

--- a/theme/base/index.html
+++ b/theme/base/index.html
@@ -121,8 +121,8 @@
                 <h1><span class="label label-default">1</span> Download</h1>
                 </div>
                     <p class="docs-lead">
-                    Welcome! This is a live preview of jQuery UI Bootstrap - a project we started to bring the beauty of Twitter <a class="targetblank" href="http://getbootstrap.com">Bootstrap</a> to jQuery UI widgets.
-                        With this theme, not only do you get the ability to use Bootstrap-themed widgets, but you can now also use (most) of Twitter Bootstrap side-by-wide with it without components breaking visually.
+                    Welcome! This is a live preview of jQuery UI Bootstrap - a project we started to bring the beauty of <a class="targetblank" href="http://getbootstrap.com">Bootstrap</a> to jQuery UI widgets.
+                        With this theme, not only do you get the ability to use Bootstrap-themed widgets, but you can now also use (most) of Bootstrap side-by-wide with it without components breaking visually.
                     </p>
                     <p>
                         <a class="download-btn ui-button-primary" href="https://github.com/addyosmani/jquery-ui-bootstrap/zipball/v0.5pre">Download stable (v0.5)</a>
@@ -136,10 +136,10 @@
                 <div class="page-header">
                 <h1><span class="label label-default">2</span> Start with jQuery UI Bootstrap</h1>
                 </div>
-                <h2>Compatibility jQuery UI and Twitter Bootstrap</h2>
+                <h2>Compatibility jQuery UI and Bootstrap</h2>
 
                 <p>
-                    In their original forms, jQuery UI and Bootstrap can't coexist resulting in conflicts with both CSS classes and styles as well as JavaScript when you do try to use them. jQuery UI Bootstrap provides the JavaScript and CSS required to quickly start a project using both jQuery UI and Twitter Bootstrap.
+                    In their original forms, jQuery UI and Bootstrap can't coexist resulting in conflicts with both CSS classes and styles as well as JavaScript when you do try to use them. jQuery UI Bootstrap provides the JavaScript and CSS required to quickly start a project using both jQuery UI and Bootstrap.
                 </p>
                 <p>
                     Our solution offers a custom version of Bootstrap compatible with jQuery UI as well as a Bootstrap-themed jQuery UI theme you can use to prototype your projects.
@@ -149,7 +149,7 @@
                     <thead>
                     <tr>
                         <th>jQuery UI</th>
-                        <th>Twitter Bootstrap</th>
+                        <th>Bootstrap</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -173,7 +173,7 @@
                     <tr>
                         <th>Widget</th>
                         <th>jQuery UI</th>
-                        <th>Twitter Bootstrap</th>
+                        <th>Bootstrap</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -192,7 +192,7 @@
                 <div class="alert alert-info">
                     <span class="icon-lightbulb icon-large"></span>  Select custom jQuery UI components (eg exclude tooltip)
                 </div>
-                <h3> Twitter Bootstrap components</h3>
+                <h3>Bootstrap components</h3>
             <div class="row">
                 <ul class="list-unstyled">
                     <li class="col-sm-6 col-lg-3 col-sm-3">
@@ -220,7 +220,7 @@
                     <tr>
                         <th>Widget</th>
                         <th>jQuery UI</th>
-                        <th>Twitter Bootstrap</th>
+                        <th>Bootstrap</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -240,7 +240,7 @@
                     Selecting which jQuery UI and Bootstrap components and styles we wish to use, we can benefit from the advantages of both projects. jQuery UI Bootstrap also provides Bootstrap theming for a number of third-party jQuery UI widgets such as the Wijmo menu widget and others.
                 </p>
                 <p>
-                    Note: if you want to use Font awesome with Twitter Bootstrap, you must exclude the CSS component icons.
+                    Note: if you want to use Font Awesome with Bootstrap, you must exclude the CSS component icons.
                 </p>
                 <p>
                     The Awesome Font documentation indicates this information perfectly.
@@ -287,7 +287,7 @@
                 <h3><span class="icon-lightbulb"></span> Credits</h3>
                 <ul class="list-unstyled">
                     <li>jQuery UI Bootstrap &copy; <strong class="text-info">Addy Osmani</strong> 2012 - 2013.</li>
-                    <li>Twitter Bootstrap &copy; <strong class="text-info">Twitter</strong> 2012 - 2013</li>
+                    <li>Bootstrap &copy; <strong class="text-info">Twitter, Inc.</strong> 2012 - 2013</li>
                 </ul>
             </div>
           </div>

--- a/theme/base/map.html
+++ b/theme/base/map.html
@@ -311,7 +311,7 @@ $("#tabs").tabs({
                 <h3><span class="icon-lightbulb"></span> Credits</h3>
                 <ul class="list-unstyled">
                     <li>jQuery UI Bootstrap &copy; <strong class="text-info">Addy Osmani</strong> 2012 - 2013.</li>
-                    <li>Twitter Bootstrap &copy; <strong class="text-info">Twitter</strong> 2012 - 2013</li>
+                    <li>Bootstrap &copy; <strong class="text-info">Twitter, Inc.</strong> 2012 - 2013</li>
                 </ul>
             </div>
           </div>

--- a/theme/united/components.html
+++ b/theme/united/components.html
@@ -1183,7 +1183,7 @@ $( "#tooltip-bottom" ).tooltip({
                     <h3><span class="icon-lightbulb"></span> Credits</h3>
                 <ul class="list-unstyled">
                         <li>jQuery UI Bootstrap &copy; <strong class="text-info">Addy Osmani</strong> 2012 - 2013.</li>
-                        <li>Twitter Bootstrap &copy; <strong class="text-info">Twitter</strong> 2012 - 2013</li>
+                        <li>Bootstrap &copy; <strong class="text-info">Twitter, Inc.</strong> 2012 - 2013</li>
                     </ul>
                 </div>
             </div>

--- a/theme/united/extra.html
+++ b/theme/united/extra.html
@@ -133,7 +133,7 @@
                     <h1>Wijmo</h1>
                 </div>
                 <p>
-                    This is an example of how to retheme one of the Wijmo jQuery UI components to match the Twitter Bootstrap theme. Whilst a menu component will be arriving to jQueryUI soon, you can find the menu in <a href="http://wijmo.com/widgets/wijmo-open/">Wijmo Open</a>.
+                    This is an example of how to retheme one of the Wijmo jQuery UI components to match the Bootstrap theme. Whilst a menu component will be arriving to jQueryUI soon, you can find the menu in <a href="http://wijmo.com/widgets/wijmo-open/">Wijmo Open</a>.
                 </p>
                 <div id="wijmo-container" class="container">
                     <ul id="menu1">
@@ -410,7 +410,7 @@ $( "#rerun-fa" )
                 <h3><span class="icon-lightbulb"></span> Credits</h3>
                 <ul class="list-unstyled">
                     <li>jQuery UI Bootstrap &copy; <strong class="text-info">Addy Osmani</strong> 2012 - 2013.</li>
-                    <li>Twitter Bootstrap &copy; <strong class="text-info">Twitter</strong> 2012 - 2013</li>
+                    <li>Bootstrap &copy; <strong class="text-info">Twitter, Inc.</strong> 2012 - 2013</li>
                 </ul>
             </div>
           </div>

--- a/theme/united/index.html
+++ b/theme/united/index.html
@@ -121,8 +121,8 @@
                 <h1><span class="label label-default">1</span> Download</h1>
                 </div>
                     <p class="docs-lead">
-                    Welcome! This is a live preview of jQuery UI Bootstrap - a project we started to bring the beauty of Twitter <a class="targetblank" href="http://getbootstrap.com">Bootstrap</a> to jQuery UI widgets.
-                        With this theme, not only do you get the ability to use Bootstrap-themed widgets, but you can now also use (most) of Twitter Bootstrap side-by-wide with it without components breaking visually.
+                    Welcome! This is a live preview of jQuery UI Bootstrap - a project we started to bring the beauty of <a class="targetblank" href="http://getbootstrap.com">Bootstrap</a> to jQuery UI widgets.
+                        With this theme, not only do you get the ability to use Bootstrap-themed widgets, but you can now also use (most) of Bootstrap side-by-wide with it without components breaking visually.
                     </p>
                     <p>
                         <a class="download-btn ui-button-primary" href="https://github.com/addyosmani/jquery-ui-bootstrap/zipball/v0.5pre">Download stable (v0.5)</a>
@@ -136,10 +136,10 @@
                 <div class="page-header">
                 <h1><span class="label label-default">2</span> Start with jQuery UI Bootstrap</h1>
                 </div>
-                <h2>Compatibility jQuery UI and Twitter Bootstrap</h2>
+                <h2>Compatibility jQuery UI and Bootstrap</h2>
 
                 <p>
-                    In their original forms, jQuery UI and Bootstrap can't coexist resulting in conflicts with both CSS classes and styles as well as JavaScript when you do try to use them. jQuery UI Bootstrap provides the JavaScript and CSS required to quickly start a project using both jQuery UI and Twitter Bootstrap.
+                    In their original forms, jQuery UI and Bootstrap can't coexist resulting in conflicts with both CSS classes and styles as well as JavaScript when you do try to use them. jQuery UI Bootstrap provides the JavaScript and CSS required to quickly start a project using both jQuery UI and Bootstrap.
                 </p>
                 <p>
                     Our solution offers a custom version of Bootstrap compatible with jQuery UI as well as a Bootstrap-themed jQuery UI theme you can use to prototype your projects.
@@ -149,7 +149,7 @@
                     <thead>
                     <tr>
                         <th>jQuery UI</th>
-                        <th>Twitter Bootstrap</th>
+                        <th>Bootstrap</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -173,7 +173,7 @@
                     <tr>
                         <th>Widget</th>
                         <th>jQuery UI</th>
-                        <th>Twitter Bootstrap</th>
+                        <th>Bootstrap</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -192,7 +192,7 @@
                 <div class="alert alert-info">
                     <span class="icon-lightbulb icon-large"></span>  Select custom jQuery UI components (eg exclude tooltip)
                 </div>
-                <h3> Twitter Bootstrap components</h3>
+                <h3>Bootstrap components</h3>
             <div class="row">
                 <ul class="list-unstyled">
                     <li class="col-sm-6 col-lg-3 col-sm-3">
@@ -220,7 +220,7 @@
                     <tr>
                         <th>Widget</th>
                         <th>jQuery UI</th>
-                        <th>Twitter Bootstrap</th>
+                        <th>Bootstrap</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -240,7 +240,7 @@
                     Selecting which jQuery UI and Bootstrap components and styles we wish to use, we can benefit from the advantages of both projects. jQuery UI Bootstrap also provides Bootstrap theming for a number of third-party jQuery UI widgets such as the Wijmo menu widget and others.
                 </p>
                 <p>
-                    Note: if you want to use Font awesome with Twitter Bootstrap, you must exclude the CSS component icons.
+                    Note: if you want to use Font Awesome with Bootstrap, you must exclude the CSS component icons.
                 </p>
                 <p>
                     The Awesome Font documentation indicates this information perfectly.
@@ -287,7 +287,7 @@
                 <h3><span class="icon-lightbulb"></span> Credits</h3>
                 <ul class="list-unstyled">
                     <li>jQuery UI Bootstrap &copy; <strong class="text-info">Addy Osmani</strong> 2012 - 2013.</li>
-                    <li>Twitter Bootstrap &copy; <strong class="text-info">Twitter</strong> 2012 - 2013</li>
+                    <li>Bootstrap &copy; <strong class="text-info">Twitter, Inc.</strong> 2012 - 2013</li>
                 </ul>
             </div>
           </div>

--- a/theme/united/map.html
+++ b/theme/united/map.html
@@ -311,7 +311,7 @@ $("#tabs").tabs({
                 <h3><span class="icon-lightbulb"></span> Credits</h3>
                 <ul class="list-unstyled">
                     <li>jQuery UI Bootstrap &copy; <strong class="text-info">Addy Osmani</strong> 2012 - 2013.</li>
-                    <li>Twitter Bootstrap &copy; <strong class="text-info">Twitter</strong> 2012 - 2013</li>
+                    <li>Bootstrap &copy; <strong class="text-info">Twitter, Inc.</strong> 2012 - 2013</li>
                 </ul>
             </div>
           </div>

--- a/third-party/jqGrid/demo.html
+++ b/third-party/jqGrid/demo.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>Bootstrap, from Twitter + jqGrid</title>
+        <title>Bootstrap + jqGrid</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="description" content="">
         <meta name="author" content="">


### PR DESCRIPTION
See http://getbootstrap.com/about/#brand
It's now simply "Bootstrap" rather than "Twitter Bootstrap".
