### PR TITLE
Fixed bug in active item of widgets.

### DIFF
--- a/css/custom-theme/jquery-ui-1.10.3.custom.css
+++ b/css/custom-theme/jquery-ui-1.10.3.custom.css
@@ -1176,7 +1176,6 @@ button.ui-button::-moz-focus-inner {
     border-color: #357EBD;
     color: #FFFFFF;
     display: block;
-    white-space: nowrap;
 }
 
 /* Fix problem with border in ui-state-active */


### PR DESCRIPTION
The "white-space: nowrap" makes the autocomplete widget fail when it has data with large labels that use two lines. It makes the label switch really fast between nowrap and default making it unusable. It still needs the wrap to make the full text viewable and is the default behavior in jQuery UI.
