### PR TITLE
Bug fix.

### DIFF
--- a/css/custom-theme/jquery-ui-1.10.3.custom.css
+++ b/css/custom-theme/jquery-ui-1.10.3.custom.css
@@ -1308,7 +1308,6 @@ button.ui-button::-moz-focus-inner {
 	left: 0;
 	padding: .2em;
 	width: 300px;
-	overflow: hidden;
 	outline: 0;
 	background-clip: padding-box;
 	background-color: #ffffff;

--- a/test/autocomplete.html
+++ b/test/autocomplete.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <script src="../assets/js/vendor/jquery-1.9.1.min.js"></script>
+        <script src="../assets/js/vendor/bootstrap.js"></script>
+        <script src="../assets/js/vendor/jquery-ui-1.10.3.custom.min.js"></script>
+        <link rel="stylesheet" href="../css/custom-theme/jquery-ui-1.10.3.custom.css"/>
+        <link rel="stylesheet" href="../assets/css/bootstrap.min.css"/>
+    </head>
+
+    <body>
+        <div>
+            <button onclick="">Open Dialog </button>
+        </div>
+        <div id="modal">
+            Name: <input id="tags" type="text" placeholder="auto-complete"/>
+        </div>
+    </body>
+
+    <script>
+        var a = [ 'AA', 'Acordion', 'Active', 'AutoComplete', 'CSS', 'C', 'C++', 'JavaScript', 'Java' ];
+
+        $('#modal').dialog({
+            autoOpen: false,
+            width: 400,
+            buttons: {
+                "OK" : function() {
+                    $(this).dialog('close');
+                },
+
+                "Cancel": function() {
+                    $(this).dialog('close');
+                }
+            }
+        });
+        $('button').click(function() {
+            $('#modal').dialog('open');    
+        });
+        
+        $('#tags').autocomplete({
+            source: a
+        });
+    </script>
+</html>


### PR DESCRIPTION
When using a dialog and autocomplete, the autocomplete box stay on
back a dialog box. A test was created to show this bug.
![autocomplete](https://cloud.githubusercontent.com/assets/811922/11454482/42cea88a-960c-11e5-8995-8ca48130b346.png)
